### PR TITLE
Scribe Common: remove dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,3 @@
 {
-  "name": "scribe-plugin-intelligent-unlink-command",
-  "dependencies": {
-    "scribe-common": "0.0.11"
-  }
+  "name": "scribe-plugin-intelligent-unlink-command"
 }

--- a/package.json
+++ b/package.json
@@ -2,16 +2,13 @@
   "name": "scribe-plugin-intelligent-unlink-command",
   "version": "0.1.4",
   "main": "src/scribe-plugin-intelligent-unlink-command.js",
-  "dependencies": {
-    "scribe-common": "~0.0.4"
-  },
   "devDependencies": {
-    "plumber": "~0.3.0",
-    "plumber-all": "~0.3.0",
-    "plumber-glob": "~0.3.0",
-    "plumber-requirejs": "~0.3.0",
-    "plumber-uglifyjs": "~0.3.0",
-    "plumber-write": "~0.3.0"
+    "plumber": "~0.4.0",
+    "plumber-all": "~0.4.0",
+    "plumber-glob": "~0.4.0",
+    "plumber-requirejs": "~0.4.0",
+    "plumber-uglifyjs": "~0.4.0",
+    "plumber-write": "~0.4.0"
   },
   "repository": {
     "type": "git",

--- a/src/scribe-plugin-intelligent-unlink-command.js
+++ b/src/scribe-plugin-intelligent-unlink-command.js
@@ -1,4 +1,4 @@
-define(['scribe-common/src/element'], function (element) {
+define([], function () {
 
   /**
    * This plugin modifies the `unlink` command so that, when the user's
@@ -9,6 +9,8 @@ define(['scribe-common/src/element'], function (element) {
 
   return function () {
     return function (scribe) {
+      var element = scribe.element;
+      
       var unlinkCommand = new scribe.api.Command('unlink');
 
       unlinkCommand.execute = function () {


### PR DESCRIPTION
Removes Scribe Common, upgrades Plumber

I'm not sure how to test this, presumably via the Scribe test file

Part of addressing [this issue](https://github.com/guardian/scribe/issues/291)
